### PR TITLE
fixed double volume indicator problem that some users have

### DIFF
--- a/blocks.h
+++ b/blocks.h
@@ -3,7 +3,7 @@ static const Block blocks[] = {
 	/*Icon*/	/*Command*/		/*Update Interval*/	/*Update Signal*/
 	{"", "cat /tmp/recordingicon",	0,	9},
 	{"📬 ", "find ~/.local/share/mail/*/INBOX/new -type f | wc -l", 0, 13},
-	{"🔊 ", "amixer get Master | grep -o \"\\(\\[off\\]\\|[0-9]*%\\)\"", 0, 10},
+	{"🔊 ", "amixer get Master | tail -n1 | grep -o \"\\(\\[off\\]\\|[0-9]*%\\)\"", 0, 10},
 	{"🔋 ", "sed \"s/$/%/\" /sys/class/power_supply/BAT?/capacity", 5, 12},
 	{"🕗 ", "date '+%Y %b %d (%a) %I:%M%p'",	60,	0},
 };


### PR DESCRIPTION
adding tail -n1 to the volume command fixes the double volume indicator problem that some users are experiencing ... althou "amixer get Master | tail -n1 | sed -r 's/.*\\[(.*)%\\].*/\\1/'" produces the same result for me, I can't tell the difference between the two, I am assuming that the [off] in your setup is supposed to display when people mute audio, but for some reason the mute keybindings from LARBS aren't working for me ....