### PR TITLE
added optional keyboard layout selection module …

### DIFF
--- a/config.h
+++ b/config.h
@@ -2,6 +2,7 @@
 static const Block blocks[] = {
 	/*Icon*/	/*Command*/		/*Update Interval*/	/*Update Signal*/
 	{"", "cat /tmp/recordingicon 2>/dev/null",	0,	9},
+	/* {" ",	"language",	0,	17}, */
 	/* {"",	"music",	0,	11}, */
 	{"",	"pacpackages",	0,	8},
 	{"",	"news",		0,	6},

--- a/config.h
+++ b/config.h
@@ -2,7 +2,6 @@
 static const Block blocks[] = {
 	/*Icon*/	/*Command*/		/*Update Interval*/	/*Update Signal*/
 	{"", "cat /tmp/recordingicon 2>/dev/null",	0,	9},
-	/* {" ",	"language",	0,	17}, */
 	/* {"",	"music",	0,	11}, */
 	{"",	"pacpackages",	0,	8},
 	{"",	"news",		0,	6},
@@ -15,6 +14,7 @@ static const Block blocks[] = {
 	{"",	"mailbox",	180,	12},
 	/* {"",	"nettraf",	1,	16}, */
 	{"",	"volume",	0,	10},
+	/* {" ",	"language",	1,	5}, */
 	{"",	"battery | tr \'\n\' \' \'",	5,	3},
 	{"",	"clock",	60,	1},
 	{"",	"internet",	5,	4},


### PR DESCRIPTION
It requires the "language" and "langselect" scripts, which use dmenu and xorg-setxkbmap for switching the keyboard layout. I will add these scripts shortly. "langselect" can also be used with a keybinding.

By default, this module shows a two-letter code representing the current keyboard layout.
- Left-click to quickly switch between two most used languages (which are English and French in my case);
- Right-click to show info;
- Middle-click to open dmenu for more language options (I have already added English, French, Ukrainian, and Russian).