### PR TITLE
Update status after forking and export with setenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ Thus, running `pkill -RTMIN+10 dwmblocks` will update it.
 Like i3blocks, this build allows you to build in additional actions into your scripts in response to click events.
 See the above linked scripts for examples of this using the `$BLOCK_BUTTON` variable.
 
-For this feature to work, you need the appropriate patch in dwm as well. See [here](https://gist.github.com/danbyl/54f7c1d57fc6507242a95b71c3d8fdea).
+For this feature to work, you need the appropriate patch in dwm as well. See [here](https://dwm.suckless.org/patches/statuscmd/).
 Credit for those patches goes to Daniel Bylinka (daniel.bylinka@gmail.com).


### PR DESCRIPTION
Forking after updating the status can feel unresponsive depending on how long it takes for the command to run.

I also made the buttonhandler code a bit cleaner by exporting with setenv and changed the credit link to the statuscmd page on suckless.org instead of the gist that I probably won't be updating in the future.