### PR TITLE
Fixed weird blocks behaviour with moving text (music, nettraf), Added support for multiple char delimiter

### DIFF
--- a/config.h
+++ b/config.h
@@ -2,7 +2,7 @@
 static const Block blocks[] = {
 	/*Icon*/	/*Command*/		/*Update Interval*/	/*Update Signal*/
 	{"", "cat /tmp/recordingicon 2>/dev/null",	0,	9},
-	/* {"",	"music",	0,	11}, */
+	{"",	"music",	0,	11},
 	{"",	"pacpackages",	0,	8},
 	{"",	"news",		0,	6},
 	/* {"",	"crypto",	0,	13}, */
@@ -24,7 +24,7 @@ static const Block blocks[] = {
 };
 
 //sets delimeter between status commands. NULL character ('\0') means no delimeter.
-static char delim = ' ';
+static char *delim = " ";
 
 // Have dwmblocks automatically recompile and run when you edit this file in
 // vim with the following line in your vimrc/init.vim:

--- a/config.h
+++ b/config.h
@@ -2,7 +2,7 @@
 static const Block blocks[] = {
 	/*Icon*/	/*Command*/		/*Update Interval*/	/*Update Signal*/
 	{"", "cat /tmp/recordingicon 2>/dev/null",	0,	9},
-	{"",	"music",	0,	11},
+	/* {"",	"music",	0,	11},*/
 	{"",	"pacpackages",	0,	8},
 	{"",	"news",		0,	6},
 	/* {"",	"crypto",	0,	13}, */

--- a/dwmblocks.c
+++ b/dwmblocks.c
@@ -75,7 +75,7 @@ void getcmd(const Block *block, char *output)
 		return;
 	char c;
 	int i = strlen(block->icon);
-	fgets(output+i, CMDLENGTH-i, cmdf);
+	fgets(output+i, CMDLENGTH-2, cmdf);
 	remove_all(output, '\n');
 	i = strlen(output);
 	if (delim != '\0' && i)

--- a/dwmblocks.c
+++ b/dwmblocks.c
@@ -75,11 +75,12 @@ void getcmd(const Block *block, char *output)
 		return;
 	char c;
 	int i = strlen(block->icon);
-	fgets(output+i, CMDLENGTH-2, cmdf);
+	fgets(output+i, CMDLENGTH-(strlen(delim)+1), cmdf);
 	remove_all(output, '\n');
 	i = strlen(output);
-	if (delim != '\0' && i)
-		output[i++] = delim;
+    if ((i > 0 && block != &blocks[LENGTH(blocks) - 1]))
+        strcat(output, delim);
+    i+=strlen(delim);
 	output[i++] = '\0';
 	pclose(cmdf);
 }
@@ -130,8 +131,11 @@ int getstatus(char *str, char *last)
 {
 	strcpy(last, str);
 	str[0] = '\0';
-	for(int i = 0; i < LENGTH(blocks); i++)
+    for(int i = 0; i < LENGTH(blocks); i++) {
 		strcat(str, statusbar[i]);
+        if (i == LENGTH(blocks) - 1)
+            strcat(str, " ");
+    }
 	str[strlen(str)-1] = '\0';
 	return strcmp(str, last);//0 if they are the same
 }
@@ -218,7 +222,7 @@ int main(int argc, char** argv)
 	for(int i = 0; i < argc; i++)
 	{
 		if (!strcmp("-d",argv[i]))
-			delim = argv[++i][0];
+			delim = argv[++i];
 		else if(!strcmp("-p",argv[i]))
 			writestatus = pstdout;
 	}


### PR DESCRIPTION
![pic-selected-200530-1210-35](https://user-images.githubusercontent.com/55378008/83320535-c13a0d00-a272-11ea-8149-0f77b5c4d566.png)
Fixed this weird issue with moving text (nettraf, music) that overrides other blocks. Also added support for multiple char delimiters.