### PR TITLE
moved 2 lines before fork() - works better for me

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,3 +1,0 @@
-github: lukesmithxyz
-custom: ["https://lukesmith.xyz/donate", "https://paypal.me/lukemsmith", "https://lukesmith.xyz/crypto"]
-patreon: lukesmith

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dwmblocks
+# dwmblocks - fork from Luke's build
 
 Modular status bar for dwm written in c.
 
@@ -6,6 +6,12 @@ Modular status bar for dwm written in c.
 
 The statusbar is made from text output from commandline programs.  Blocks are
 added and removed by editing the config.h file.
+
+# My build
+
+The patches in the patch/ Directory did not work for me, so I removed them.
+Everything else is taken from Luke's build.
+
 
 # Luke's build
 

--- a/config.h
+++ b/config.h
@@ -1,14 +1,14 @@
 //Modify this file to change what commands output to your statusbar, and recompile using the make command.
 static const Block blocks[] = {
-    /*Icon*/ /*Command*/   /*Update Interval*/ /*Update Signal*/
-    {"",      "music",          0,              11},
-    {"",      "moonphase",  18000,               4},
-    {"",      "weather",    18000,               5},
-    {"",      "volume",         0,              10},
-    {"",      "nettraf",       10,              16},
-    {"",      "clock",         10,               6},
-    {"",      "killwin",        0,              15},
+    /*Icon*/    /*Command*/        /*Update Interval*/    /*Update Signal*/
+    {"",    "music",         0,    11},
+    {"",    "moonphase", 18000,     4},
+    {"",    "weather",   18000,     5},
+    {"",    "volume",        0,    10},
+    {"",    "nettraf",      10,    16},
+    {"",    "clock",        10,     6},
+    {"",    "killwin",       0,    15},
 };
 
 //sets delimeter between status commands. NULL character ('\0') means no delimeter.
-static char *delim = "|";
+static char delim = '|';

--- a/config.h
+++ b/config.h
@@ -1,32 +1,14 @@
 //Modify this file to change what commands output to your statusbar, and recompile using the make command.
 static const Block blocks[] = {
-	/*Icon*/	/*Command*/		/*Update Interval*/	/*Update Signal*/
-	{"", "cat /tmp/recordingicon 2>/dev/null",	0,	9},
-	/* {"",	"music",	0,	11},*/
-	{"",	"pacpackages",	0,	8},
-	{"",	"news",		0,	6},
-	/* {"",	"crypto",	0,	13}, */
-	/* {"",	"price bat \"Basic Attention Token\" 🦁",	0,	20}, */
-	/* {"",	"price btc Bitcoin 💰",				0,	21}, */
-	/* {"",	"price lbc \"LBRY Token\" 📚",			0,	22}, */
-	{"",	"torrent",	20,	7},
-	/* {"",	"memory",	10,	14}, */
-	/* {"",	"cpu",		10,	18}, */
-	/* {"",	"moonphase",	18000,	17}, */
-	{"",	"weather",	18000,	5},
-	{"",	"mailbox",	180,	12},
-	/* {"",	"nettraf",	1,	16}, */
-	{"",	"volume",	0,	10},
-	{"",	"battery",	5,	3},
-	{"",	"clock",	60,	1},
-	{"",	"internet",	5,	4},
-	{"",	"help-icon",	0,	15},
+    /*Icon*/ /*Command*/   /*Update Interval*/ /*Update Signal*/
+    {"",      "music",          0,              11},
+    {"",      "moonphase",  18000,               4},
+    {"",      "weather",    18000,               5},
+    {"",      "volume",         0,              10},
+    {"",      "nettraf",       10,              16},
+    {"",      "clock",         10,               6},
+    {"",      "killwin",        0,              15},
 };
 
 //sets delimeter between status commands. NULL character ('\0') means no delimeter.
-static char *delim = " ";
-
-// Have dwmblocks automatically recompile and run when you edit this file in
-// vim with the following line in your vimrc/init.vim:
-
-// autocmd BufWritePost ~/.local/src/dwmblocks/config.h !cd ~/.local/src/dwmblocks/; sudo make install && { killall -q dwmblocks;setsid dwmblocks & }
+static char *delim = "|";

--- a/dwmblocks.c
+++ b/dwmblocks.c
@@ -194,6 +194,8 @@ void buttonhandler(int sig, siginfo_t *si, void *ucontext)
 {
 	char button[2] = {'0' + si->si_value.sival_int & 0xff, '\0'};
 	sig = si->si_value.sival_int >> 8;
+	getsigcmds(sig);
+	writestatus();
 	if (fork() == 0)
 	{
 		const Block *current;
@@ -209,8 +211,6 @@ void buttonhandler(int sig, siginfo_t *si, void *ucontext)
 		execvp(command[0], command);
 		exit(EXIT_SUCCESS);
 	}
-	getsigcmds(sig);
-	writestatus();
 }
 
 #endif


### PR DESCRIPTION
Hi Luke,

I noticed, that with your dwmblocks build, if clicked in the status bar the corresponding script were run twice at the same time (once with BUTTON_BLOCK set, once without)... these gave me some headache, especially for scripts which do some kind of toggling (example mute/unmute - first run muted, sendond run unmuted - nothing happend.). 

I just moved 2 lines before the fork() and this works much better for me, but to be honest I don't really know what I'm doing, and maybe this change is plain wrong.

Anyway, just to let you know, maybe it's just with my build, maybe you experience similar problems, maybe there is already a patch around.

