### PR TITLE
small fix for "remove_all" function, now it works properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,8 @@ of this using the `$BLOCK_BUTTON` variable.
 For this feature to work, you need the appropriate patch in dwm as well. See
 [here](https://dwm.suckless.org/patches/statuscmd/).
 Credit for those patches goes to Daniel Bylinka (daniel.bylinka@gmail.com).
+
+# There is a problem of slightly lagging
+
+so far I don't know the mechanism of this issue.
+

--- a/README.md
+++ b/README.md
@@ -47,5 +47,12 @@ Credit for those patches goes to Daniel Bylinka (daniel.bylinka@gmail.com).
 
 # There is a problem of slightly lagging
 
-so far I don't know the mechanism of this issue.
+if color scheme changing is send thourgh text like \x01 \x02 .
+and the copyvalidchars from rawstext to stext is set allow to pass them.
+then dwm will not like it, and lag the switching.
+
+but createing a new sibling for stext for example "ctext" in dwm
+wont cause it lag.
+
+
 

--- a/dwmblocks.c
+++ b/dwmblocks.c
@@ -51,13 +51,11 @@ void remove_all(char *str, char to_remove) {
 	char *read = str;
 	char *write = str;
 	while (*read) {
-		if (*read == to_remove) {
-			read++;
-			*write = *read;
-		}
+		if (*read == to_remove) write++
 		read++;
-		write++;
+		*write = *read;
 	}
+	*write = *read;
 }
 
 //opens process *cmd and stores output in *output

--- a/dwmblocks.c
+++ b/dwmblocks.c
@@ -51,7 +51,7 @@ void remove_all(char *str, char to_remove) {
 	char *read = str;
 	char *write = str;
 	while (*read) {
-		if (*read == to_remove) write++
+		if (*read != to_remove) write++
 		read++;
 		*write = *read;
 	}


### PR DESCRIPTION
before it only removes the one and only last "to_remove" characters. and terribly mess up the string.

now it removes all the "to_remove" characters.