### PR TITLE
Change KBSelect Program To Include SB Prefix

### DIFF
--- a/config.h
+++ b/config.h
@@ -1,7 +1,7 @@
 //Modify this file to change what commands output to your statusbar, and recompile using the make command.
 static const Block blocks[] = {
 	/*Icon*/	/*Command*/		/*Update Interval*/	/*Update Signal*/
-	/* {"⌨", "kbselect", 0, 30}, */
+	/* {"⌨", "sb-kbselect", 0, 30}, */
 	{"", "cat /tmp/recordingicon 2>/dev/null",	0,	9},
 	{"",	"sb-tasks",	10,	26},
 	{"",	"sb-music",	0,	11},


### PR DESCRIPTION
Obviously nothing major, just changing the typo "kbselect" to "sb-kbselect", but should help keep things consistent.