### PR TITLE
ignore real-time signals by default, unless explicitly set

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,7 @@ but is faster.  Just add 34 to your typical signal number.
 My volume module *never* updates on its own, instead I have this command run
 along side my volume shortcuts in dwm to only update it when relevant.
 
-Note that if you signal an unexpected signal to dwmblocks, it will probably
-crash. So if you disable a module, remember to also disable any cronjobs or
-other scripts that might signal to that module.
-
-Note also that all modules must have different signal numbers.
+Note that all modules must have different signal numbers.
 
 # Clickable modules
 

--- a/dwmblocks.c
+++ b/dwmblocks.c
@@ -111,6 +111,10 @@ void getsigcmds(int signal)
 void setupsignals()
 {
 	struct sigaction sa;
+
+	for(int i = SIGRTMIN; i <= SIGRTMAX; i++)
+		signal(i, SIG_IGN);
+
 	for(int i = 0; i < LENGTH(blocks); i++)
 	{
 		if (blocks[i].signal > 0)


### PR DESCRIPTION
This resolves #63 by setting dwmblocks to ignore real-time signals unless explicitly set in `config.h`.