### PR TITLE
Fix Fast Scrolling Disappearing Blocks

### DIFF
--- a/config.h
+++ b/config.h
@@ -1,32 +1,20 @@
 //Modify this file to change what commands output to your statusbar, and recompile using the make command.
 static const Block blocks[] = {
 	/*Icon*/	/*Command*/		/*Update Interval*/	/*Update Signal*/
-	{"", "cat /tmp/recordingicon 2>/dev/null",	0,	9},
 	/* {"",	"music",	0,	11},*/
-	{"",	"pacpackages",	0,	8},
-	{"",	"news",		0,	6},
-	/* {"",	"crypto",	0,	13}, */
-	/* {"",	"price bat \"Basic Attention Token\" 🦁",	0,	20}, */
-	/* {"",	"price btc Bitcoin 💰",				0,	21}, */
-	/* {"",	"price lbc \"LBRY Token\" 📚",			0,	22}, */
-	{"",	"torrent",	20,	7},
+	/* {"",	"pacpackages",	0,	8}, */
 	/* {"",	"memory",	10,	14}, */
-	/* {"",	"cpu",		10,	18}, */
-	/* {"",	"moonphase",	18000,	17}, */
-	{"",	"weather",	18000,	5},
-	{"",	"mailbox",	180,	12},
+	/* {"",	"weather",	18000,	5}, */
+	/* {"",	"mailbox",	180,	12}, */
 	/* {"",	"nettraf",	1,	16}, */
-	{"",	"volume",	0,	10},
+	/* {"",	"volume",	0,	10}, */
+    /* {"",	"internet",	5,	4}, */
+    {"",    "stalonetray.sh", 0, 27},
+    {"",	"cpupercent.sh",	1,	19},
 	{"",	"battery",	5,	3},
-	{"",	"clock",	60,	1},
-	{"",	"internet",	5,	4},
-	{"",	"help-icon",	0,	15},
+	{"",	"clock",	1,	1},
 };
 
 //sets delimeter between status commands. NULL character ('\0') means no delimeter.
-static char *delim = " ";
+static char *delim = "|";
 
-// Have dwmblocks automatically recompile and run when you edit this file in
-// vim with the following line in your vimrc/init.vim:
-
-// autocmd BufWritePost ~/.local/src/dwmblocks/config.h !cd ~/.local/src/dwmblocks/; sudo make install && { killall -q dwmblocks;setsid dwmblocks & }

--- a/config.h
+++ b/config.h
@@ -10,7 +10,16 @@ static const Block blocks[] = {
 	/* {"",	"volume",	0,	10}, */
     /* {"",	"internet",	5,	4}, */
     {"",    "stalonetray.sh", 0, 27},
+    /* {"?",   "sleep 2s && date", 1, 8}, */
     {"",	"cpupercent.sh",	1,	19},
 	{"",	"battery",	5,	3},
 	{"",	"clock",	1,	1},
 };
+
+//Sets delimiter between status commands. NULL character ('\0') means no delimiter.
+static char *delim = "|";
+
+// Have dwmblocks automatically recompile and run when you edit this file in
+// vim with the following line in your vimrc/init.vim:
+
+// autocmd BufWritePost ~/.local/src/dwmblocks/config.h !cd ~/.local/src/dwmblocks/; sudo make install && { killall -q dwmblocks;setsid dwmblocks & }

--- a/config.h
+++ b/config.h
@@ -1,23 +1,34 @@
 //Modify this file to change what commands output to your statusbar, and recompile using the make command.
 static const Block blocks[] = {
 	/*Icon*/	/*Command*/		/*Update Interval*/	/*Update Signal*/
-	/* {"",	"music",	0,	11},*/
-	/* {"",	"pacpackages",	0,	8}, */
-	/* {"",	"memory",	10,	14}, */
-	/* {"",	"weather",	18000,	5}, */
-	/* {"",	"mailbox",	180,	12}, */
-	/* {"",	"nettraf",	1,	16}, */
-	/* {"",	"volume",	0,	10}, */
-    /* {"",	"internet",	5,	4}, */
-    {"",    "stalonetray.sh", 0, 27},
-    /* {"?",   "sleep 2s && date", 1, 8}, */
-    {"",	"cpupercent.sh",	1,	19},
-	{"",	"battery",	5,	3},
-	{"",	"clock",	1,	1},
+	/* {"⌨", "sb-kbselect", 0, 30}, */
+	{"", "cat /tmp/recordingicon 2>/dev/null",	0,	9},
+	{"",	"sb-tasks",	10,	26},
+	{"",	"sb-music",	0,	11},
+	{"",	"sb-pacpackages",	0,	8},
+	{"",	"sb-news",		0,	6},
+	/* {"",	"sb-price lbc \"LBRY Token\" 📚",			9000,	22}, */
+	/* {"",	"sb-price bat \"Basic Attention Token\" 🦁",	9000,	20}, */
+	/* {"",	"sb-price link \"Chainlink\" 🔗",			300,	25}, */
+	/* {"",	"sb-price xmr \"Monero\" 🔒",			9000,	24}, */
+	/* {"",	"sb-price eth Ethereum 🍸",	9000,	23}, */
+	/* {"",	"sb-price btc Bitcoin 💰",				9000,	21}, */
+	{"",	"sb-torrent",	20,	7},
+	/* {"",	"sb-memory",	10,	14}, */
+	/* {"",	"sb-cpu",		10,	18}, */
+	/* {"",	"sb-moonphase",	18000,	17}, */
+	{"",	"sb-forecast",	18000,	5},
+	{"",	"sb-mailbox",	180,	12},
+	{"",	"sb-nettraf",	1,	16},
+	{"",	"sb-volume",	0,	10},
+	{"",	"sb-battery",	5,	3},
+	{"",	"sb-clock",	60,	1},
+	{"",	"sb-internet",	5,	4},
+	{"",	"sb-help-icon",	0,	15},
 };
 
 //Sets delimiter between status commands. NULL character ('\0') means no delimiter.
-static char *delim = "|";
+static char *delim = " ";
 
 // Have dwmblocks automatically recompile and run when you edit this file in
 // vim with the following line in your vimrc/init.vim:

--- a/dwmblocks.c
+++ b/dwmblocks.c
@@ -97,11 +97,10 @@ void getcmd(const Block *block, char *output)
 	char * s;
     int e;
     do {
+        errno = 0;
         s = fgets(tmpstr, CMDLENGTH-(strlen(delim)+1), cmdf);
         e = errno;
     } while (!s && e == EINTR);
-    // this is equivalent but less readable and stuff
-    //while(!fgets(tmpstr, CMDLENGTH-(strlen(delim)+1), cmdf) && errno == EINTR);
 	pclose(cmdf);
 	int i = strlen(block->icon);
 	strcpy(output, block->icon);

--- a/dwmblocks.c
+++ b/dwmblocks.c
@@ -2,6 +2,7 @@
 #include<stdio.h>
 #include<string.h>
 #include<unistd.h>
+#include <time.h>
 #include<signal.h>
 #include<X11/Xlib.h>
 #define LENGTH(X)               (sizeof(X) / sizeof (X[0]))
@@ -91,8 +92,9 @@ void getcmds(int time)
 	for(int i = 0; i < LENGTH(blocks); i++)
 	{
 		current = blocks + i;
-		if ((current->interval != 0 && time % current->interval == 0) || time == -1)
+		if ((current->interval != 0 && time % current->interval == 0) || time == -1){
 			getcmd(current,statusbar[i]);
+        }
 	}
 }
 
@@ -103,8 +105,9 @@ void getsigcmds(int signal)
 	for (int i = 0; i < LENGTH(blocks); i++)
 	{
 		current = blocks + i;
-		if (current->signal == signal)
+		if (current->signal == signal){
 			getcmd(current,statusbar[i]);
+        }
 	}
 }
 
@@ -173,13 +176,27 @@ void statusloop()
 	setupsignals();
 #endif
 	int i = 0;
+	int previ = -1;
+    int gotscrewed = 0;
+    struct timespec sleeptime = {1, 0};
+    struct timespec left;
 	getcmds(-1);
 	while(statusContinue)
 	{
-		getcmds(i);
-		writestatus();
-		sleep(1.0);
-		i++;
+        if(i != previ){
+            getcmds(i);
+            writestatus();
+        }
+        gotscrewed = nanosleep(&sleeptime, &left);
+        previ = i;
+        /* long diff = (left.tv_sec + (left.tv_nsec + 500000000l) / 1000000000l); */
+        /* i += 1 - diff; */
+        if(gotscrewed != -1){
+            i++;
+        /* }else{ */
+        /*     printf("sec and nanosec left: %d, %d", left.tv_sec, left.tv_nsec); */
+        }
+
 	}
 }
 

--- a/dwmblocks.c
+++ b/dwmblocks.c
@@ -219,7 +219,7 @@ void statusloop()
     }
 	unsigned int i = 0;
     int interrupted = 0;
-    struct timespec sleeptime = {interval, 0};
+    const struct timespec sleeptime = {interval, 0};
     struct timespec tosleep = sleeptime;
 	getcmds(-1);
 	while(statusContinue)
@@ -234,7 +234,7 @@ void statusloop()
         getcmds(i);
         writestatus();
         // then increment since its actually been a second (plus the time it took the commands to run)
-        i++;
+        i += interval;
         // set the time to sleep back to the sleeptime of 1s
         tosleep = sleeptime;
 	}


### PR DESCRIPTION
Fixed the issue in #51 without breaking causing the issue in #65.  This fix reads attempts to read the output of the command run until it can successfully without failing due to the interrupt send from the fast scroll.  This branch also fixes the issue with the interrupt halting the sleep early, causing the blocks to be updated prematurely.  This fix does not store the previous value, so it should not have issues where it wont allow blocks to disappear if they have not output.  A better explanation is given here https://github.com/LukeSmithxyz/dwmblocks/issues/51#issuecomment-798892610.
This branch does also have other smaller changes (as you can see in the diffs) that I can take out if desired.