### PR TITLE
Improve performance by sleeping as much as possible

### DIFF
--- a/dwmblocks.c
+++ b/dwmblocks.c
@@ -38,6 +38,7 @@ static char statusbar[LENGTH(blocks)][CMDLENGTH] = {0};
 static char statusstr[2][256];
 static int statusContinue = 1;
 static void (*writestatus) () = setroot;
+static int interval = -1;
 
 void replace(char *str, char old, char new)
 {
@@ -182,7 +183,7 @@ void statusloop()
 	{
 		getcmds(i);
 		writestatus();
-		sleep(1.0);
+		sleep(interval);
 		i++;
 	}
 }
@@ -226,6 +227,19 @@ void termhandler(int signum)
 	exit(0);
 }
 
+static int gcd(int a, int b)
+{
+	int temp;
+	while (b > 0)
+	{
+		temp = a % b;
+
+		a = b;
+		b = temp;
+	}
+	return a;
+}
+
 int main(int argc, char** argv)
 {
 	for(int i = 0; i < argc; i++)
@@ -235,6 +249,13 @@ int main(int argc, char** argv)
 		else if(!strcmp("-p",argv[i]))
 			writestatus = pstdout;
 	}
+
+	for (int i = 0; i < LENGTH(blocks); i++) {
+		if (blocks[i].interval != 0) {
+			interval = gcd(blocks[i].interval, interval);
+		}
+	}
+
 	signal(SIGTERM, termhandler);
 	signal(SIGINT, termhandler);
 	statusloop();

--- a/patches/dwmblocks-gcd.diff
+++ b/patches/dwmblocks-gcd.diff
@@ -1,0 +1,55 @@
+diff --git a/dwmblocks.c b/dwmblocks.c
+index 18f58fb..aaddd0d 100644
+--- a/dwmblocks.c
++++ b/dwmblocks.c
+@@ -38,6 +38,7 @@ static char statusbar[LENGTH(blocks)][CMDLENGTH] = {0};
+ static char statusstr[2][256];
+ static int statusContinue = 1;
+ static void (*writestatus) () = setroot;
++static int interval = -1;
+ 
+ void replace(char *str, char old, char new)
+ {
+@@ -182,7 +183,7 @@ void statusloop()
+ 	{
+ 		getcmds(i);
+ 		writestatus();
+-		sleep(1.0);
++		sleep(interval);
+ 		i++;
+ 	}
+ }
+@@ -226,6 +227,19 @@ void termhandler(int signum)
+ 	exit(0);
+ }
+ 
++static int gcd(int a, int b)
++{
++	int temp;
++	while (b > 0)
++	{
++		temp = a % b;
++
++		a = b;
++		b = temp;
++	}
++	return a;
++}
++
+ int main(int argc, char** argv)
+ {
+ 	for(int i = 0; i < argc; i++)
+@@ -235,6 +249,13 @@ int main(int argc, char** argv)
+ 		else if(!strcmp("-p",argv[i]))
+ 			writestatus = pstdout;
+ 	}
++
++	for (int i = 0; i < LENGTH(blocks); i++) {
++		if (blocks[i].interval != 0) {
++			interval = gcd(blocks[i].interval, interval);
++		}
++	}
++
+ 	signal(SIGTERM, termhandler);
+ 	signal(SIGINT, termhandler);
+ 	statusloop();


### PR DESCRIPTION
In your video, you said dwmblocks is much more efficient compared to shell scripts, because it only updates when signalled.
Well, this was not the case. If all blocks had a timeout of a minute, dwmblocks would have still woken up every second to check, if it needed to update anything yet.
This PR tries to fix this issue by computing the gcd at startup.

ie:
Having two blocks, with timeouts of 5 and 30 would compute 5 as the wakeup interval.
Having two blocks, with timeout 7 and 8 would use 1, since they don't have a common denominator.

Now, where this comes in handy is when having a bar that is fully updated by signals (timeout 0).
This code would compute -1, which is 4294967295 seconds, which is 136 years (forever), so dwmblocks would only wake up when signalled.