### PR TITLE
Replace buggy implementation of function 'remove_all()'.

### DIFF
--- a/dwmblocks.c
+++ b/dwmblocks.c
@@ -51,13 +51,13 @@ void remove_all(char *str, char to_remove) {
 	char *read = str;
 	char *write = str;
 	while (*read) {
-		if (*read == to_remove) {
-			read++;
+		if (*read != to_remove) {
 			*write = *read;
+			++write;
 		}
-		read++;
-		write++;
+		++read;
 	}
+	*write = '\0';
 }
 
 //opens process *cmd and stores output in *output


### PR DESCRIPTION
Hey Luke!

I was casually browsing code of your fork of dwmblocks and noticed that implementation of 'remove_all()' function looks funny. I looked into it more closely and yes, there is a bug. Below is code for separate C program that demonstrates it:

```c
#include <stdio.h>
#include <string.h>

void remove_all(char *str, char to_remove) {
        char *read = str;
        char *write = str;
        while (*read) {
                if (*read == to_remove) {
                        read++;
                        *write = *read;
                }
                read++;
                write++;
        }
}

int main() {
        char str[] = "aaa";
        remove_all(str, 'a');
        printf("Result is: \"%s\"\n", str);
        return 0;
}
```

Output:

```
gcc main.c -o main
./main
Result is: "a"
```

Actually we were lucky it didn't crash, as `read` pointer was reading garbage after `str` buffer. It just so happened that value of that garbage was equal to `\0`. 

Please review my fix. 