### PR TITLE
Update names of the scripts (removing sb- prefix)

### DIFF
--- a/config.h
+++ b/config.h
@@ -3,28 +3,28 @@ static const Block blocks[] = {
 	/*Icon*/	/*Command*/		/*Update Interval*/	/*Update Signal*/
 	/* {"⌨", "sb-kbselect", 0, 30}, */
 	{"", "cat /tmp/recordingicon 2>/dev/null",	0,	9},
-	{"",	"sb-tasks",	10,	26},
-	{"",	"sb-music",	0,	11},
-	{"",	"sb-pacpackages",	0,	8},
-	{"",	"sb-news",		0,	6},
-	/* {"",	"sb-price lbc \"LBRY Token\" 📚",			9000,	22}, */
-	/* {"",	"sb-price bat \"Basic Attention Token\" 🦁",	9000,	20}, */
-	/* {"",	"sb-price link \"Chainlink\" 🔗",			300,	25}, */
-	/* {"",	"sb-price xmr \"Monero\" 🔒",			9000,	24}, */
-	/* {"",	"sb-price eth Ethereum 🍸",	9000,	23}, */
-	/* {"",	"sb-price btc Bitcoin 💰",				9000,	21}, */
-	{"",	"sb-torrent",	20,	7},
-	/* {"",	"sb-memory",	10,	14}, */
-	/* {"",	"sb-cpu",		10,	18}, */
-	/* {"",	"sb-moonphase",	18000,	17}, */
-	{"",	"sb-forecast",	18000,	5},
-	{"",	"sb-mailbox",	180,	12},
-	{"",	"sb-nettraf",	1,	16},
-	{"",	"sb-volume",	0,	10},
-	{"",	"sb-battery",	5,	3},
-	{"",	"sb-clock",	60,	1},
-	{"",	"sb-internet",	5,	4},
-	{"",	"sb-help-icon",	0,	15},
+	{"",	"tasks",	10,	26},
+	{"",	"music",	0,	11},
+	{"",	"pacpackages",	0,	8},
+	{"",	"news",		0,	6},
+	/* {"",	"price lbc \"LBRY Token\" 📚",			9000,	22}, */
+	/* {"",	"price bat \"Basic Attention Token\" 🦁",	9000,	20}, */
+	/* {"",	"price link \"Chainlink\" 🔗",			300,	25}, */
+	/* {"",	"price xmr \"Monero\" 🔒",			9000,	24}, */
+	/* {"",	"price eth Ethereum 🍸",	9000,	23}, */
+	/* {"",	"price btc Bitcoin 💰",				9000,	21}, */
+	{"",	"torrent",	20,	7},
+	/* {"",	"memory",	10,	14}, */
+	/* {"",	"cpu",		10,	18}, */
+	/* {"",	"moonphase",	18000,	17}, */
+	{"",	"forecast",	18000,	5},
+	{"",	"mailbox",	180,	12},
+	{"",	"nettraf",	1,	16},
+	{"",	"volume",	0,	10},
+	{"",	"battery",	5,	3},
+	{"",	"clock",	60,	1},
+	{"",	"internet",	5,	4},
+	{"",	"help-icon",	0,	15},
 };
 
 //Sets delimiter between status commands. NULL character ('\0') means no delimiter.


### PR DESCRIPTION
The names of the scripts in `~/.local/bin/statusbar/` were changed to not include "sb-" prefix. Therefore they need also an update on this config.