### PR TITLE
Changed crypto Emojies to Font-Awesome logos

### DIFF
--- a/config.h
+++ b/config.h
@@ -10,9 +10,9 @@ static const Block blocks[] = {
 	/* {"",	"sb-price lbc \"LBRY Token\" 📚",			9000,	22}, */
 	/* {"",	"sb-price bat \"Basic Attention Token\" 🦁",	9000,	20}, */
 	/* {"",	"sb-price link \"Chainlink\" 🔗",			300,	25}, */
-	/* {"",	"sb-price xmr \"Monero\" 🔒",			9000,	24}, */
-	/* {"",	"sb-price eth Ethereum 🍸",	9000,	23}, */
-	/* {"",	"sb-price btc Bitcoin 💰",				9000,	21}, */
+	/* {"",	"sb-price xmr \"Monero\" ",			9000,	24}, */
+	/* {"",	"sb-price eth Ethereum ",	9000,	23}, */
+	/* {"",	"sb-price btc Bitcoin ",				9000,	21}, */
 	{"",	"sb-torrent",	20,	7},
 	/* {"",	"sb-memory",	10,	14}, */
 	/* {"",	"sb-cpu",		10,	18}, */


### PR DESCRIPTION
Thought it was a little confusing the emojis used. I've seen former commits using font-awesome so i hope is alright. 
The font required can be downloaded via 
Arch: `sudo pacman -S ttf-font-awesome` 
Debian: `sudo apt-get install fonts-font-awesome`
I did no other configs
This is how it looks:
![This is an image](https://raw.githubusercontent.com/LalleSX/LalleSX/main/pix/pic-selected-220618-1645-10.png)