### PR TITLE
Install to ${HOME}/.local instead of /usr/local.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .POSIX:
 
-PREFIX = /usr/local
+PREFIX = ${HOME}/.local
 CC = gcc
 
 dwmblocks: dwmblocks.o


### PR DESCRIPTION
Rationale:
- Private config.h settings do not spill to other users on multi-user systems
- No more sudo make install