### PR TITLE
Fix statusbar freezing

### DIFF
--- a/dwmblocks.c
+++ b/dwmblocks.c
@@ -186,6 +186,9 @@ void setroot()
 	/* block all signals until after root updated */
 	sigset_t new, old;
 	sigfillset(&new);
+	sigdelset(&new, SIGINT);
+	sigdelset(&new, SIGTERM);
+
 	if (sigprocmask(SIG_SETMASK, &new, &old) < 0) {
 		perror("sigset");
 		exit(1);

--- a/dwmblocks.c
+++ b/dwmblocks.c
@@ -183,6 +183,14 @@ int getstatus(char *str, char *last)
 
 void setroot()
 {
+	/* block all signals until after root updated */
+	sigset_t new, old;
+	sigfillset(&new);
+	if (sigprocmask(SIG_SETMASK, &new, &old) < 0) {
+		perror("sigset");
+		exit(1);
+	}
+
 	if (!getstatus(statusstr[0], statusstr[1]))//Only set root if text has changed.
 		return;
 	Display *d = XOpenDisplay(NULL);
@@ -192,7 +200,10 @@ void setroot()
 	screen = DefaultScreen(dpy);
 	root = RootWindow(dpy, screen);
 	XStoreName(dpy, root, statusstr[0]);
-	XCloseDisplay(dpy);
+	XCloseDisplay(d);
+
+	/* restore signals to default */
+	sigprocmask(SIG_SETMASK, &old, NULL);
 }
 
 void pstdout()


### PR DESCRIPTION
Block signal handlers from running recursively (when a handler is already running) to avoid deadlock on Xorg connection. It seems that they changed the function to include some mutual exclusion lock that's getting locked on connection. Shouldn't affect anything else.

Fixes #102