### PR TITLE
Change dwmblocks to use an asynchronous approach to executing blocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 .POSIX:
 
 PREFIX = /usr/local
+CFLAGS = -Wall -Wextra -std=c99 -pedantic -O2
+LDFLAGS = -lX11 -lrt
 CC = gcc
 
 dwmblocks: dwmblocks.o
-	$(CC) dwmblocks.o -lX11 -o dwmblocks
+	$(CC) dwmblocks.o $(CFLAGS) $(LDFLAGS) -o dwmblocks
 dwmblocks.o: dwmblocks.c config.h
 	$(CC) -c dwmblocks.c
 clean:


### PR DESCRIPTION
This PR changes the way dwmblocks functions. Instead of sleeping and checking periodically if a blocks needs to be updated a POSIX interval timer is created for each block. On expiry of this timer a either a signal is sent to the process by the kernel that invokes the signal handler for that block or if the block is setup with a signal of 0 a new thread is spawned for the block which executes the command provided to said block.

The main process after setting up each timer simply calls pause() and waits for a delivery of a signal.

These changes *should* improve performance and reduce CPU usage.

The program now also needs to be linked with `-lrt`.