### PR TITLE
Don't print anything for the current block if command doesn't return any text

### DIFF
--- a/config.h
+++ b/config.h
@@ -31,6 +31,8 @@ static const Block blocks[] = {
 //Sets delimiter between status commands. NULL character ('\0') means no delimiter.
 static char *delim = " ";
 
+static int hideemptyblock = 1; // Hide icon if command returns nothing
+
 // Have dwmblocks automatically recompile and run when you edit this file in
 // vim with the following line in your vimrc/init.vim:
 

--- a/dwmblocks.c
+++ b/dwmblocks.c
@@ -105,7 +105,13 @@ void getcmd(const Block *block, char *output)
     } while (!s && e == EINTR);
 	pclose(cmdf);
 	int i = strlen(block->icon);
-	strcpy(output, block->icon);
+
+    if (s && hideemptyblock || !hideemptyblock) {
+        strcpy(output, block->icon);
+    } else {
+        strcpy(output, "");
+    }
+
     strcpy(output+i, tmpstr);
 	remove_all(output, '\n');
 	i = strlen(output);


### PR DESCRIPTION
Don't know if this is something you will find useful, as it seems the icon is empty for all your blocks anyway, but this PR simply makes sure the icon doesn't get printed if there's no command alongside it.

Have tested this and it seems to work perfectly. I'm also using it in my own build where I originally implemented it. I decided to create this pull request since you may find it useful.

You can of course also toggle this feature through changing the value of hideemptyblock. Let me know if there are issues with this, but I haven't been able to find any!